### PR TITLE
Add Favorites Page with Remove Option and Navigation Button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,7 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Accueil from "./pages/LandingPage";
 import Pokemon from "./pages/PokemonPage";
-import TypesPokemonSection from "./components/sections/TypesPokemonSection"
-import FonctionnalitésSections from './components/sections/FonctionnalitésSections';
+import FavorisPages from './pages/FavorisPage';
 
 function App() {
   return (
@@ -10,6 +9,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Accueil />} />
         <Route path="/pokemon" element={<Pokemon />}/>
+        <Route path="/favoris" element={<FavorisPages />}/>
       </Routes>
     </Router>
   );

--- a/src/components/communs/Header.jsx
+++ b/src/components/communs/Header.jsx
@@ -46,6 +46,12 @@ const Header = () => {
             >
               Fonctionnalités
             </a>
+            <Link 
+              to="/favoris" 
+              className="text-gray-600 dark:text-gray-300 hover:text-red-600 dark:hover:text-red-400 transition-colors font-medium"
+            >
+              Mes favoris
+            </Link>
           </nav>
 
           {/* Right Section - Button and Menu */}

--- a/src/pages/FavorisPage.jsx
+++ b/src/pages/FavorisPage.jsx
@@ -1,0 +1,29 @@
+import Header from '../components/communs/Header';
+import Footer from '../components/communs/Footer';
+import FavoritePokemonList from '../components/FavoritePokemonList';
+import { Link } from 'react-router-dom';
+
+function FavorisPages() {
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-red-50 dark:from-slate-900 dark:via-slate-800 dark:to-slate-900 text-slate-800 dark:text-white">
+      <Header />
+      <main className='px-5 pt-10 pb-20'>
+        <FavoritePokemonList />
+        <div className="flex justify-center mt-10">
+            <Link to="/pokemon">
+                <button
+                    className="bg-yellow-400 hover:bg-yellow-300 text-gray-900 px-6 py-3 rounded-lg font-bold text-lg flex items-center gap-2 transition-colors"
+                >
+                    Explorer maintenant
+                </button>
+            </Link>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
+
+export default FavorisPages;


### PR DESCRIPTION
### Description

This PR introduces a complete **Favorites Page** that displays the user's favorite Pokémon saved in localStorage. Key features include:

- 🔥 Display of all favorite Pokémon with the same modern design as the main Pokémon list
- ❤️ Ability to remove a Pokémon from favorites using a heart toggle or a trash icon
- 🧭 A clearly visible and centered "Explorer maintenant" button to navigate back to the main Pokémon page
- ♻️ Reuse of the existing `<Details />` component for detailed view modals

All styles are consistent with the rest of the application, using TailwindCSS and dark mode compatibility.

---

### ✅ To Do After Merge
- Add routing from homepage to `/favoris` if not yet done
- Optionally add a toast/notification when a Pokémon is removed

---

### 🧪 Tested
- Favorites persist correctly in `localStorage`
- Pokémon can be removed from favorites
- Modal opens correctly from the favorites page
- Responsive and visually aligned layout
